### PR TITLE
add OctoAcme project management README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# Scale institutional knowledge using Copilot Spaces
+# OctoAcme Project Management Docs — README
 
-<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
+Welcome to the OctoAcme project management documentation hub. This folder centralizes our processes, templates, and decision records to make delivery predictable, transparent, and easy for new teammates to adopt.
 
-Hey ansyeow!
+OctoAcme runs projects through a structured lifecycle: initiation (one‑pagers to capture problem, goal, and stakeholders), planning (breakdown into a prioritized backlog, estimates, and a Definition of Done), execution (project board with Backlog → Ready → In Progress → In Review → QA → Done and a PR-driven workflow), release (typed releases with pre-release checklists, smoke tests, and rollback plans), and retrospective (timeboxed reviews that convert action items into backlog tasks). Roles are explicit — Product Managers define outcomes and success metrics, Project Managers coordinate schedules and risks, Developers deliver and test, and QA validates acceptance criteria — with named PM and Product Lead ownership for each project.
 
-Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
+Communication is regular and intentional: daily standups for progress and blockers, weekly delivery syncs and PM+PdM check‑ins, demos at milestone boundaries, and monthly stakeholder updates. A single source of truth (the project README or release document) and a weekly status template keep stakeholders aligned. Blockers escalate via a clear path (team → PM → Product Lead → Sponsor) and incident communications follow a playbook for rapid response.
 
-Remember, it's self-paced so feel free to take a break! ☕️
+Quality and risk management are integrated into day‑to‑day work: CI runs unit/integration tests and security scans, small PRs include acceptance criteria and require at least one approval, critical flows have end‑to‑end smoke tests, and manual QA is used for acceptance when needed. Risks are tracked in a risk register and reviewed regularly; retrospectives capture improvements and convert them into actionable backlog items.
 
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/ansyeow/skills-scale-institutional-knowledge-using-copilot-spaces/issues/1)
+OctoAcme Process Docs
+- octoacme-project-management-overview.md
+- octoacme-project-initiation.md
+- octoacme-project-planning.md
+- octoacme-execution-and-tracking.md
+- octoacme-risks-and-communication.md
+- octoacme-release-and-deployment.md
+- octoacme-retrospective-and-continuous-improvement.md
+- octoacme-roles-and-personas.md
 
----
-
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
-
+Need a change or to add more detail? Use the Add Content to Project Management Process Docs issue template in .github/ISSUE_TEMPLATE/.


### PR DESCRIPTION
Closes #2

Adds docs/README.md summarizing OctoAcme project management processes and linking to existing process docs.